### PR TITLE
[16.0][IMP] sale_global_discount: refactor _compute_amounts

### DIFF
--- a/sale_global_discount/README.rst
+++ b/sale_global_discount/README.rst
@@ -88,6 +88,10 @@ Contributors
   * David Vidal
   * Pedro M. Baeza
 * Omar Castiñeira <omar@comunitea.com>
+* `Trobz <https://www.trobz.com>`_
+
+  * Quoc Duong
+  * Tris Doan
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_global_discount/readme/CONTRIBUTORS.rst
+++ b/sale_global_discount/readme/CONTRIBUTORS.rst
@@ -3,3 +3,7 @@
   * David Vidal
   * Pedro M. Baeza
 * Omar Castiñeira <omar@comunitea.com>
+* `Trobz <https://www.trobz.com>`_
+
+  * Quoc Duong
+  * Tris Doan

--- a/sale_global_discount/static/description/index.html
+++ b/sale_global_discount/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -437,12 +438,19 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Omar Castiñeira &lt;<a class="reference external" href="mailto:omar&#64;comunitea.com">omar&#64;comunitea.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.trobz.com">Trobz</a><ul>
+<li>Quoc Duong</li>
+<li>Tris Doan</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
### Context
- Before this change, it results in rounding issue. It happens when products are configured as tax-included in price

![sample_sale_global_discount](https://github.com/trisdoan/sale-workflow/assets/88806544/513d414d-c0d3-49ad-ad53-17fe66731792)

- In Sale Order (without sale global discount), taxes are unnecessarily recomputed, which results in wrongly computation.

### This change
- Add a check to only recompute tax when global discount is applied on the sale order.