### PR TITLE
[16.0][IMP] sale_order_product_recommendation_quick_add: add return keyword

### DIFF
--- a/sale_order_product_recommendation_quick_add/README.rst
+++ b/sale_order_product_recommendation_quick_add/README.rst
@@ -58,6 +58,8 @@ Contributors
 ~~~~~~~~~~~~
 
 * Telmo Santos <telmo.santos@camptocamp.com>
+* Tris Doan <tridm@trobz.com>
+
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_order_product_recommendation_quick_add/models/sale_order.py
+++ b/sale_order_product_recommendation_quick_add/models/sale_order.py
@@ -14,4 +14,4 @@ class SaleOrder(models.Model):
             .create({})
         )
         so_recomendation_wiz.generate_recommendations()
-        so_recomendation_wiz.action_accept()
+        return so_recomendation_wiz.action_accept()

--- a/sale_order_product_recommendation_quick_add/readme/CONTRIBUTORS.rst
+++ b/sale_order_product_recommendation_quick_add/readme/CONTRIBUTORS.rst
@@ -1,1 +1,3 @@
 * Telmo Santos <telmo.santos@camptocamp.com>
+* Tris Doan <tridm@trobz.com>
+

--- a/sale_order_product_recommendation_quick_add/static/description/index.html
+++ b/sale_order_product_recommendation_quick_add/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -403,12 +404,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
 <ul class="simple">
 <li>Telmo Santos &lt;<a class="reference external" href="mailto:telmo.santos&#64;camptocamp.com">telmo.santos&#64;camptocamp.com</a>&gt;</li>
+<li>Tris Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
### This change
- Add 'return' keyword allows continuing function chain, e.g: viewing SO lines after clicking 'Quick Add' https://github.com/trisdoan/sale-workflow/pull/13